### PR TITLE
fix: add shebang and fix yoga-wasm-web bundling

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentech1/cc-sync",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude Code configuration sync across devices",
   "type": "module",
   "bin": {
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "bun run src/index.tsx",
     "dev:watch": "bun run --watch src/index.tsx",
-    "build": "bun build src/index.tsx --outdir dist --target bun && bun build src/daemon.ts --outdir dist --target bun",
+    "build": "bun build src/index.tsx --outdir dist --target node --external yoga-wasm-web && bun build src/daemon.ts --outdir dist --target node && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.tmp && mv dist/index.tmp dist/index.js && chmod +x dist/index.js",
     "start": "bun run dist/index.js",
     "type-check": "tsc --noEmit",
     "test:sync": "bun run src/test-sync.ts",
@@ -41,7 +41,8 @@
     "ink": "^4.4.1",
     "ink-text-input": "^6.0.0",
     "keytar": "^7.9.0",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "yoga-wasm-web": "^0.3.3"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
     },
     "apps/cli": {
       "name": "@opentech1/cc-sync",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "cc-sync": "./dist/index.js",
       },
@@ -45,6 +45,7 @@
         "ink-text-input": "^6.0.0",
         "keytar": "^7.9.0",
         "react": "^18.2.0",
+        "yoga-wasm-web": "^0.3.3",
       },
       "devDependencies": {
         "@types/bun": "latest",


### PR DESCRIPTION
## Summary
- Add #!/usr/bin/env node shebang to bundled CLI for proper execution
- Mark yoga-wasm-web as external to fix WASM loading issues
- Add yoga-wasm-web as runtime dependency
- Bump version to 0.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)