### PR TITLE
fix: use Convex site URL directly for auth client

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,3 +256,4 @@ MIT
 - Auth powered by [Better Auth](https://better-auth.com)
 - CLI powered by [OpenTUI](https://github.com/opentui/opentui)
 - Monorepo managed by [TurboRepo](https://turbo.build)
+# trigger redeploy Fri Nov 21 16:21:15 EST 2025

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -2,5 +2,6 @@ import { convexClient } from "@convex-dev/better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
+  baseURL: process.env.NEXT_PUBLIC_CONVEX_SITE_URL,
   plugins: [convexClient()],
 });


### PR DESCRIPTION
Bypasses Next.js proxy for auth - calls Convex directly to fix 404 errors