### PR TITLE
fix: hardcode Convex URL fallback for auth client

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,7 +1,10 @@
 import { convexClient } from "@convex-dev/better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
+// Use Convex site URL directly for auth - env var should work but hardcoding for reliability
+const CONVEX_SITE_URL = process.env.NEXT_PUBLIC_CONVEX_SITE_URL || "https://beloved-poodle-251.convex.site";
+
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_CONVEX_SITE_URL,
+  baseURL: CONVEX_SITE_URL,
   plugins: [convexClient()],
 });


### PR DESCRIPTION
Ensures auth works even if env var is missing