### PR TITLE
fix: add outputDirectory to vercel.json

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "cd ../.. && bun install",
-  "buildCommand": "cd ../.. && bun run --filter web build"
+  "buildCommand": "cd ../.. && bun run --filter web build",
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
Fix Vercel looking in wrong place for Next.js output