### PR TITLE
Fix trailing slash in Convex site URL

### DIFF
--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -2,9 +2,11 @@
 // The original nextJsHandler forwards the Host header from the incoming request,
 // which causes Convex to reject the request with a 404.
 
-const CONVEX_SITE_URL =
+// Remove trailing slash if present
+const CONVEX_SITE_URL = (
   process.env.NEXT_PUBLIC_CONVEX_SITE_URL ||
-  "https://beloved-poodle-251.convex.site";
+  "https://beloved-poodle-251.convex.site"
+).replace(/\/$/, "");
 
 const handler = async (request: Request) => {
   const requestUrl = new URL(request.url);

--- a/apps/web/src/app/api/debug/route.ts
+++ b/apps/web/src/app/api/debug/route.ts
@@ -1,6 +1,6 @@
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
-  const convexSiteUrl = process.env.NEXT_PUBLIC_CONVEX_SITE_URL || "https://beloved-poodle-251.convex.site";
+  const convexSiteUrl = (process.env.NEXT_PUBLIC_CONVEX_SITE_URL || "https://beloved-poodle-251.convex.site").replace(/\/$/, "");
 
   // Test what URL would be constructed for auth
   const testPath = "/api/auth/get-session";


### PR DESCRIPTION
The NEXT_PUBLIC_CONVEX_SITE_URL env var has a trailing slash, causing double slashes in the URL path.