### PR TITLE
Fix Convex client URL for production

### DIFF
--- a/apps/web/src/components/ConvexClientProvider.tsx
+++ b/apps/web/src/components/ConvexClientProvider.tsx
@@ -5,12 +5,14 @@ import { ConvexBetterAuthProvider } from "@convex-dev/better-auth/react";
 import { ReactNode } from "react";
 import { ConvexReactClient } from "convex/react";
 
-const convex = new ConvexReactClient(
-  process.env.NEXT_PUBLIC_CONVEX_URL || "https://hardy-greyhound-996.convex.cloud",
-  {
-    expectAuth: true,
-  },
-);
+// Normalize URL by removing trailing slash
+const convexUrl = (
+  process.env.NEXT_PUBLIC_CONVEX_URL || "https://beloved-poodle-251.convex.cloud"
+).replace(/\/$/, "");
+
+const convex = new ConvexReactClient(convexUrl, {
+  expectAuth: true,
+});
 
 export default function ConvexClientProvider({
   children,


### PR DESCRIPTION
- Updates default Convex URL to production (beloved-poodle-251.convex.cloud)
- Normalizes URL to remove trailing slashes