### PR TITLE
fix: externalize keytar to fix Linux compatibility

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentech1/cc-sync",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Claude Code configuration sync across devices",
   "type": "module",
   "bin": {
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "bun run src/index.tsx",
     "dev:watch": "bun run --watch src/index.tsx",
-    "build": "bun build src/index.tsx --outdir dist --target node --external yoga-wasm-web && bun build src/daemon.ts --outdir dist --target node && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.tmp && mv dist/index.tmp dist/index.js && chmod +x dist/index.js",
+    "build": "bun build src/index.tsx --outdir dist --target node --external yoga-wasm-web --external keytar && bun build src/daemon.ts --outdir dist --target node --external keytar && echo '#!/usr/bin/env node' | cat - dist/index.js > dist/index.tmp && mv dist/index.tmp dist/index.js && chmod +x dist/index.js",
     "start": "bun run dist/index.js",
     "type-check": "tsc --noEmit",
     "test:sync": "bun run src/test-sync.ts",


### PR DESCRIPTION
## Summary

- Fixes #18 - Package fails on Linux with "invalid ELF header"
- Mark `keytar` as external in the build so it's not bundled
- Users will get the correct platform-specific prebuilt binary when installing

## Root Cause

Bun bundler was including the native `keytar` module (`.node` file) in the dist folder, but this binary was compiled for macOS ARM64 only. Linux users got the macOS binary which couldn't be loaded.

## Fix

Added `--external keytar` to both build commands in package.json. This prevents the native module from being bundled - instead, keytar is loaded at runtime from node_modules where npm/bun installs the correct platform-specific prebuilt binary.

## Test plan

- [ ] Verify the `.node` file is not in dist folder after build
- [ ] Test on Linux that the package works correctly
- [ ] Publish v0.1.4 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)